### PR TITLE
Added missing property to BackgroundTaskBuilder

### DIFF
--- a/winrt/winrt.d.ts
+++ b/winrt/winrt.d.ts
@@ -786,6 +786,7 @@ declare module Windows {
             export class BackgroundTaskBuilder implements Windows.ApplicationModel.Background.IBackgroundTaskBuilder {
                 name: string;
                 taskEntryPoint: string;
+                cancelOnConditionLoss: boolean;
                 setTrigger(trigger: Windows.ApplicationModel.Background.IBackgroundTrigger): void;
                 addCondition(condition: Windows.ApplicationModel.Background.IBackgroundCondition): void;
                 register(): Windows.ApplicationModel.Background.BackgroundTaskRegistration;


### PR DESCRIPTION
cancelOnConditionLoss is needed to be able to cancel the background task if at least one of its required conditions is no longer met.

This addresses the issue #4114
